### PR TITLE
Update 04-form-basics.md

### DIFF
--- a/docs/getting-started/04-form-basics.md
+++ b/docs/getting-started/04-form-basics.md
@@ -240,7 +240,7 @@ class ContentViewModel extends FutureViewModel<Posts> {
 }
 
 // Do instead
-class ContentViewModel extends FutureViewModel<Posts> with FormStateHelper{
+class ContentViewModel extends FutureViewModel<Posts> with FormStateHelper implements FormViewModel {
   ...
 }
 ```


### PR DESCRIPTION
Without the interface, the `syncFormWithViewModel` will complain saying that viewModel is not a FormViewModel